### PR TITLE
Fix widget naming inside localstorage on prod mode

### DIFF
--- a/smartwidgets/jarvis.widget.ng2.js
+++ b/smartwidgets/jarvis.widget.ng2.js
@@ -199,7 +199,10 @@
             // TODO : Push state does not work on IE9, try to find a way to detect IE and use a seperate filter
 
 			if (self.o.ajaxnav === true) {
-				var widget_url = location.hash.replace(/^#/, '');
+                const hash = location.hash;
+                var widget_url = hash
+                    ? hash.replace(/^#/, '') 
+                    : location.pathname;
 				self.storage.keySettings = 'Plugin_settings_' + widget_url + '_' + self.objId;
 				self.storage.keyPosition = 'Plugin_position_' + widget_url + '_' + self.objId;
 			} else if (self.initialized === false) {


### PR DESCRIPTION
As I seen inside the code, `widget_url` are made based on `location.hash` while in localhost URL are something like `localhost/#/page` the `hash` returns `/page` but on prod there is no `#` and URL are looks like `ww.site.com/page` so `hash` is undefined while `location.pathname` returns `/page` ( Same like hash on localhost ). 

Example why is that important: 
![screenshot from 2017-08-24 11-54-07](https://user-images.githubusercontent.com/25903855/29658646-565d82d4-88c4-11e7-8319-0f7646d54a56.png)
This two local storage item represents totally different pages which because of that mistake are sharing the widgets between.

https://github.com/MitocGroup/atm/issues/1308
